### PR TITLE
DJ Trainee Manual Updates from pd@

### DIFF
--- a/amm/amm.tex
+++ b/amm/amm.tex
@@ -334,7 +334,7 @@ Sexual misconduct concerns should be brought to the Member at Large.
 Equipment failures should be reported using the Equipment Support Ticket System
 found in the tabs of \href{https://witr.rit.edu/dj/}{witr.rit.edu/dj}.  You can
 use one of the office computers to do this if needed.  The system reports any
-equipment problems to the Chief Engineer. If the situation isan emergency
+equipment problems to the Chief Engineer. If the situation is an emergency
 warranting immediate attention, contact the Chief Engineer directly.
 
 \section{Food, Drink, Coats, and Bags}
@@ -565,14 +565,16 @@ Underwriting, as defined by the FCC, may include the following:
 \end{tightitemize}
 
 \section{Transmitter Controls}
-If needed, the transmitter can be operated by the remote in Studio A.  The two 
-white arrow buttons select the channel to control. Channel 1 is essentially an
-on/off switch for the transmitter and should usually show something above zero.  
-Channel 2 controls the output power. The red ``down'' and green ``up'' buttons
-change the values displayed.  However, the new transmitter doesn't really use the
-remote, so don't be too worried if it shows something else.
+If needed, the transmitter can be operated by the remote in Studio A.  In the
+normal course of your duties in the station, you will probably never need to
+touch the transmitter controls.  The two white arrow buttons select the channel
+to control. Channel 1 is essentially an on/off switch for the transmitter and
+should usually show something above zero.  Channel 2 controls the output power.
+The red ``down'' and green ``up'' buttons change the values displayed.  The
+current transmitter may not show the correct values on Channel 1, but it should
+display the correct output power level on Channel 2.
 
-There are also three lights on the side of the remote that indicates the
+There are also eight lights on the side of the remote which indicate the
 transmitter's status.  If any of lights 1--8 are on, notify the Chief Engineer
 immediately. Pay special attention to the following lights:
 \begin{itemize}
@@ -584,15 +586,15 @@ immediately. Pay special attention to the following lights:
     \item \textbf{Light 2} --- Light 2 indicates that the transmitter is turned
         off.
     \item \textbf{Light 4} --- Light 4 indicates that the transmitter is muted.
-        It may light up when the transmitter is off.
+        It may also light up when the transmitter is off.
 \end{itemize}
 
 It is \textbf{extremely} illegal to leave transmitter controls unattended. This
 means leaving the station outside of the control of either a DJ or the automated
 DJ system. Doing so could cause dead air, which is a waste of resources and 
-severely frowned upon by the FCC\@. If a person who is supposed to 
-take over for a DJ after a show does not show up and automation is unavailable,
-the last DJ in the staton must ``Sign Off'' and shut down the transmitter.
+severely frowned upon by the FCC\@. If a person who is supposed to take over for
+a DJ after a show does not show up and automation is unavailable, the last DJ in
+the staton must ``Sign Off'' and shut down the transmitter.
 
 FCC regulations require that you make transmitter controls inaccessible to
 unauthorized people. That means that members must be conscious of closing all

--- a/amm/amm.tex
+++ b/amm/amm.tex
@@ -81,7 +81,7 @@
 \chapter{Welcome to WITR 89.7}
 
 WITR is a volunteer-based organization run by the students of the Rochester
-Institute of Technology.  Operating in a professional manner is what keeps WITR
+Institute of Technology.  Operating in a professional manner keeps WITR
 89.7 on the air and allows us to broadcast the best new music to the Rochester
 community and beyond.  This manual will provide you with the information you
 need to know about WITR’s operations and policies in order to be involved with
@@ -192,13 +192,13 @@ within the station.
 The Program Director oversees all on-air content, organizes DJ shows, and
 ensures quality of programming.
 
-\textbf{Manages} --- Assistant Program Director, Music Director, News Director,
+\textbf{Manages} --- Assistant Program Director, Music Director, 
 Sports Director, Production Director, Production Team
 
 \subsection{Chief Engineer}
 The Chief Engineer oversees the technical operation of the station, the
-maintenance of all equipment, and the maintenance of the WITR website. He or she
-serves as the station’s Chief Operator.
+maintenance of all equipment, and the maintenance of the WITR website. They
+serve as the station’s Chief Operator.
 
 \textbf{Manages} --- Staff Engineers, Internal Developer, Engineering Department
 
@@ -272,7 +272,8 @@ participating in service events sponsored by WITR department heads.
 % Hyperlinks are done with \href{url}{displayed text}
 In order to receive credit for your services, you must record your station hours
 online in the Station Hours Form found online at
-\href{http://witr.rit.edu/dj}{witr.rit.edu/dj}. Station Hours earned by
+\href{http://witr.rit.edu/dj}{witr.rit.edu/dj}. If you do not have a DJ login, you
+may use any of the computers in the office.  Station Hours earned by
 reviewing CDs are the one exception to this, as the Music Director records them
 automatically. Those who do not meet the 8-hour requirement are subject to a
 suspension of privileges.
@@ -331,10 +332,10 @@ Sexual misconduct concerns should be brought to the Member at Large.
 % bracketed argument is the url to link to; the second one is the text to
 % display on the page.
 Equipment failures should be reported using the Equipment Support Ticket System
-found in the tabs of \href{https://witr.rit.edu/dj/}{witr.rit.edu/dj}. The
-system reports any equipment problems to the Chief Engineer. If the situation is
-an emergency warranting immediate attention, contact the Chief Engineer
-directly.
+found in the tabs of \href{https://witr.rit.edu/dj/}{witr.rit.edu/dj}.  You can
+use one of the office computers to do this if needed.  The system reports any
+equipment problems to the Chief Engineer. If the situation isan emergency
+warranting immediate attention, contact the Chief Engineer directly.
 
 \section{Food, Drink, Coats, and Bags}
 Coats and bags are allowed under the coat rack in the downstairs office. Food
@@ -404,132 +405,6 @@ In each section of the log, you will find:
 Should you make an error while filling out the logs, cross it out with a single
 line, place your initials next to the mistake, and date it. You may then fill in
 the correct values.
-
-\chapter{Transmitter Operation}
-Knowing how to use the transmitter remote control is an essential part of being
-a member of WITR\@. All members must be familiar with the basic operation and
-emergency procedures surrounding the transmitter. If something goes wrong with
-the transmitter, immediately contact the \textbf{Chief Engineer} and
-\textbf{General Manager}.
-
-\section{Location}
-The transmitter remote control is located in Studio A. As previously stated, our
-actual transmitter is located on top of Mark Ellingson Hall (Building 50A/MEH).
-
-\section{Channel Keys}
-There are two white buttons located on the transmitter remote. These buttons
-function similarly to a TV channel controls in that they change the channel that
-is currently active. The left button, with an outline of an up arrow, increases
-the current channel while the right button, with an outline of a down arrow,
-decreases the current channel. Just as different TV channels show different
-things, these channels also show different things. For station operation, a
-general member only needs to worry about two channels: Channel 1 and Channel 2.
-
-\section{Channel 1}
-Channel 1 is only to be used when turning the transmitter on and off. It
-essentially serves as the on/off switch for the transmitter. It is used to
-display and manipulate the transmitter’s power source. If the transmitter is on,
-it will show a voltage much greater than 0. If not, the reading will show
-something around 0.00 volts. Pressing the red ``down'' button will turn the
-transmitter off if you are in Channel 1. Pressing the green ``up'' button will
-turn the transmitter on is the transmitter is off.
-
-With the recent installation of our new transmitter, the remote retains
-functionality, but may not display the current voltage. This is does not
-indicate that we are not broadcasting and should not be a cause for concern.
-
-\section{Channel 2}
-Channel 2 is used to display and manipulate the transmitter’s output power. In
-other words, it displays how strong our current signal is. Pressing the green
-``up'' button will increase power while pressing the red ``down'' button will
-decrease power.
-
-In summary, we use \textbf{Channel 1 to turn the transmitter on and off} and use
-\textbf{Channel 2 to read and adjust the power}.
-
-\section{Status Lights}
-Small red status lights can be found on the left side of the remote. They
-indicate problems or other information about the transmitter. If any light from
-1--8 is on, you are probably not on air and do not have control of the
-transmitter. Special attention should be paid to the following three status
-lights:
-\begin{itemize}
-    \item \textbf{Light 1} --- The interlock light indicates that we’ve lost
-        contact with the transmitter. This means that someone is on the roof of
-        Ellingson. However, the transmitter may still be on despite of this.
-        Check the on-air feed in the office to verify that WITR is still
-        broadcasting.
-    \item \textbf{Light 2} --- Light 2 indicates that the transmitter is turned
-        off.
-    \item \textbf{Light 4} --- Light 4 indicates that the transmitter is muted.
-        It may light up when the transmitter is off.
-\end{itemize}
-
-\section{How to Power Up and ``Sign On''}
-The following procedure should be followed in order to properly and legally turn
-on the transmitter and begin broadcast:
-\begin{enumerate}
-    \item On the transmitter remote control, select \textbf{Channel 1} by using
-        the white channel keys
-    \item Push the \textbf{green ``up'' button} once to turn the transmitter on.
-        Light 2 should turn off to indicate that the transmitter is back on.
-    \item When the transmitter voltage has stopped moving, play the
-        \textbf{``FCC Sign On''} audio file found in the playout software. There
-        should also be a CD in both stuidos with emergency imaging. As noted
-        before, with the installation of our new transmitter, the voltage may
-        not be displayed.
-    \item Sign in on the FCC daily logs. Indicate the event in the FCC logs by
-        writing \textbf{``Power Up''} in the power column.
-\end{enumerate}
-
-\section{How to Power Down and ``Sign Off''}
-The following procedure should be followed in order to properly and legally turn
-off the transmitter and sign off.
-\begin{enumerate}
-    \item Indicate the power down event in the FCC logs by writing
-        \textbf{``Power Down''} in the power column and signing out.
-    \item Use exit delay in order to ensure that the entire sign-off file plays.
-        On the board, press the \textbf{``Dump''} button, then press
-        \textbf{``Exit Delay''}.
-    \item Play the \textbf{``FCC Sign Off''} audio file found on the computer.
-        There should also be a CD located in both studios with emergency
-        imaging.
-    \item On the transmitter remote, select \textbf{Channel 1} by using the
-        white channel keys.
-    \item As soon as the file finishes playing, push the \textbf{red ``down''
-        button} to turn the transmitter off. \textbf{Light 2} should light up
-        indicating that the transmitter is turned off.
-    \item Listen to the on-air office feed to ensure that we are actually
-        off-air. You should hear static, and possibly muddled voices.
-\end{enumerate}
-
-\section{Adjusting Transmitter Power Levels}
-WITR’s legal transmitter output is \textbf{936 watts, plus 5\% or minus 10\%}.
-936 watts is the transmitter power required to radiate an Effective Radiated
-Power of 910 watts. This allows for error in other parts of the system, such as
-remote control calibration and transmitter calibration. If the power is high or
-low, complete the following procedure to correct the error:
-\begin{enumerate}
-    \item Record the current power level in the power column of the FCC logs.
-    \item Ensure that the remote control is on \textbf{Channel 2}
-    \item Push the \textbf{red ``down'' button} or the \textbf{green ``up''
-        button} once and watch the reading. Repeat until the power is at or
-        close to 936 watts.
-    \item When the power is as close to 936 watts as possible, indicate the
-        event by writing \textbf{``Adjusted Power''} in the power column of the
-        FCC logs and including the new power level.
-\end{enumerate}
-
-As stated before, with the installation of our new transmitter, the current
-power levels may not be displaying on the remote control. If you have any
-concerns regarding the state of transmitter power levels, contact the Chief
-Engineer.
-
-\section{Emergency Alert System}
-The Emergency Alert System, referred to as the EAS, is fully automated and run
-from the blue unit in the rack inside of The Pit. Should an alert be issued, the
-EAS will automatically cut over a broadcast. No recording is necessary, but
-\textbf{it is strictly against WITR policy to acknowledge an alert on air}.
 
 \chapter{FCC Rules and Regulations}
 The following regulations are set by the FCC and apply to all radio broadcasts
@@ -644,6 +519,12 @@ the computer. When announcing the legal ID, WITR must be pronounced as
 individual letters (``W-I-T-R''). ``Witter'' is only our station’s nickname and
 is not considered a legal ID\@.
 
+\section{Emergency Alert System}
+The Emergency Alert System, referred to as the EAS, is fully automated and run
+from the blue unit in the rack inside of The Pit. Should an alert be issued, the
+EAS will automatically cut over a broadcast. No recording is necessary, but
+\textbf{it is strictly against WITR policy to acknowledge an alert on air}.
+
 \section{Safe Harbor Hours}
 The FCC defines safe harbor hours as 22:00--06:00. However, \textbf{WITR policy
 does not recognize safe harbor hours}. Indecent or profane material may
@@ -683,12 +564,35 @@ Underwriting, as defined by the FCC, may include the following:
     \item Product or service listings
 \end{tightitemize}
 
-\section{Leaving Transmitter Controls Unattended}
-It is \textbf{extremely} illegal to leave transmitter controls unattended. Doing
-so could cause dead air, which is a waste of resources and severely frowned upon
-in the eyes of the FCC\@. If a person who is supposed to take over for a DJ after
-a show does not show up and automation is unavailable, the current DJ must power
-down the transmitter.
+\section{Transmitter Controls}
+If needed, the transmitter can be operated by the remote in Studio A.  The two 
+white arrow buttons select the channel to control. Channel 1 is essentially an
+on/off switch for the transmitter and should usually show something above zero.  
+Channel 2 controls the output power. The red ``down'' and green ``up'' buttons
+change the values displayed.  However, the new transmitter doesn't really use the
+remote, so don't be too worried if it shows something else.
+
+There are also three lights on the side of the remote that indicates the
+transmitter's status.  If any of lights 1--8 are on, notify the Chief Engineer
+immediately. Pay special attention to the following lights:
+\begin{itemize}
+    \item \textbf{Light 1} --- The interlock light indicates that we’ve lost
+        contact with the transmitter. This means that someone is on the roof of
+        Ellingson. However, the transmitter may still be on despite of this.
+        Check the on-air feed in the office to verify that WITR is still
+        broadcasting.
+    \item \textbf{Light 2} --- Light 2 indicates that the transmitter is turned
+        off.
+    \item \textbf{Light 4} --- Light 4 indicates that the transmitter is muted.
+        It may light up when the transmitter is off.
+\end{itemize}
+
+It is \textbf{extremely} illegal to leave transmitter controls unattended. This
+means leaving the station outside of the control of either a DJ or the automated
+DJ system. Doing so could cause dead air, which is a waste of resources and 
+severely frowned upon by the FCC\@. If a person who is supposed to 
+take over for a DJ after a show does not show up and automation is unavailable,
+the last DJ in the staton must ``Sign Off'' and shut down the transmitter.
 
 FCC regulations require that you make transmitter controls inaccessible to
 unauthorized people. That means that members must be conscious of closing all

--- a/amm/amm.tex
+++ b/amm/amm.tex
@@ -29,7 +29,7 @@
 
 % Style Notes
 
-% To save future members from typographic atrocities, please only use the
+% To save future members from typographic atrocities, please *only* use the
 % \textbf{} macro for emphasis.  Do not put things in all caps.  Do not
 % underline them.  Do not italicize them.  Just use bold.
 

--- a/trainee/djtraining.tex
+++ b/trainee/djtraining.tex
@@ -2,7 +2,7 @@
 \usepackage{wrapfig}
 
 \title{DJ TRAINING MANUAL}
-\date{SPRING 2019}
+\date{FALL 2020}
 \renewcommand{\LogoColor}{white}
 % This is witr-yellow and not just yellow because this refers to a color defined
 % in the documentclass, not to part of the filename of the graphic.

--- a/trainer/djtrainer.tex
+++ b/trainer/djtrainer.tex
@@ -4,7 +4,7 @@
 
 \setsecnumdepth{none}
 \title{DJ TRAINER GUIDE}
-\date{SPRING 2019}
+\date{FALL 2020}
 \renewcommand{\LogoColor}{yellow}
 \renewcommand{\TitleColor}{black}
 


### PR DESCRIPTION
These updates consist of minor spelling mistake corrections and clarity edits. They also consistently use “station hours” over “work hours,” which is a term we no longer say.